### PR TITLE
Optimize UPS Rating Requests

### DIFF
--- a/src/carriers/AbstractCarrier.php
+++ b/src/carriers/AbstractCarrier.php
@@ -215,6 +215,7 @@ abstract class AbstractCarrier extends Model implements CarrierInterface
         $this->beforeFetchRates($request);
 
         $httpClient = $request->getHttpClient() ?? $this->getHttpClient();
+        $request->setHttpClient($httpClient);
         $baseUri = $httpClient ? (string)$httpClient->getConfig('base_uri') : '';
 
         Shippy::debug('{name} Rate Request [{method}]: {baseUri}{endpoint}: {payload}', [

--- a/src/carriers/UPS.php
+++ b/src/carriers/UPS.php
@@ -132,6 +132,8 @@ class UPS extends AbstractCarrier
     protected bool $addDeclaredValue = false;
     protected string $apiVersion = 'v2409';
 
+    private static array $accessTokenCache = [];
+
     private array $pickupCodes = [
         '01' => 'Daily Pickup',
         '03' => 'Customer Counter',
@@ -517,6 +519,29 @@ class UPS extends AbstractCarrier
         $transactionSrc = 'Shippy ' . InstalledVersions::getPrettyVersion('verbb/shippy');
 
         // Fetch an access token first
+
+        $accessToken = $this->getAccessToken($url);
+
+        return new HttpClient([
+            'base_uri' => $url,
+            'headers' => [
+                'Authorization' => 'Bearer ' . $accessToken,
+                'Content-Type' => 'application/json',
+                'transId' => $transId,
+                'transactionSrc' => $transactionSrc,
+            ],
+        ]);
+    }
+
+    protected function getAccessToken(string $url): string
+    {
+        $cacheKey = md5($url . '|' . $this->clientId);
+        $cachedToken = self::$accessTokenCache[$cacheKey] ?? null;
+
+        if (($cachedToken['expiresAt'] ?? 0) > time()) {
+            return $cachedToken['token'];
+        }
+
         $authResponse = Json::decode((string)(new HttpClient())
             ->request('POST', $url . "security/v1/oauth/token", [
                 'headers' => [
@@ -529,15 +554,17 @@ class UPS extends AbstractCarrier
                 ],
             ])->getBody());
 
-        return new HttpClient([
-            'base_uri' => $url,
-            'headers' => [
-                'Authorization' => 'Bearer ' . $authResponse['access_token'] ?? '',
-                'Content-Type' => 'application/json',
-                'transId' => $transId,
-                'transactionSrc' => $transactionSrc,
-            ],
-        ]);
+        $accessToken = $authResponse['access_token'] ?? '';
+
+        if ($accessToken !== '') {
+            $ttl = max(60, (int)($authResponse['expires_in'] ?? 3600) - 60);
+            self::$accessTokenCache[$cacheKey] = [
+                'token' => $accessToken,
+                'expiresAt' => time() + $ttl,
+            ];
+        }
+
+        return $accessToken;
     }
 
 


### PR DESCRIPTION
- Reuse the resolved HTTP client during rate fetches by assigning it back to the request.
- Cache UPS OAuth access tokens in a framework-agnostic in-memory cache until shortly before expiry.
- Avoid duplicate OAuth/client setup during UPS rating requests.